### PR TITLE
fixed gi version import and formatted imports

### DIFF
--- a/falabracman.py
+++ b/falabracman.py
@@ -17,19 +17,23 @@
 # You should have received a copy of the GNU General Public License
 # along with Falabracman.  If not, see <http://www.gnu.org/licenses/>.
 
-from gi.repository import Gtk
+import os
+import hollow
+import gettext
 import pygame
+import random
+import sys
+
+import gi
+gi.require_version('Gtk', '3.0')
+
+from gi.repository import Gtk
+from gi.repository import Gdk
+
+from config import *
 from pygame.locals import *
 from random import randrange
-import random
-import gettext
-import hollow
-from config import *
-import gi
-import sys
-import os
-from gi.repository import Gdk
-gi.require_version('Gtk', '3.0')
+
 
 # CONSTANTS
 FBM_SPEED = 15


### PR DESCRIPTION
![Screenshot 2023-02-23 102328](https://user-images.githubusercontent.com/96080203/220835332-1f7581e2-4e50-4f7e-8752-a3f43d193f03.jpg)

> This warning was shown whenever starting the activity

The reason for this warning was that the gi version requirement is specified before importing gi dependencies but it was being done the other way around so i moved the version declaration above the import statements to fix this

Also, I noticed that the format of imports generally followed in sugar activities was not being followed by this one's import section so I formatted the section accordingly as well